### PR TITLE
Implement http.Handler on ResponseRecorder.

### DIFF
--- a/slash.go
+++ b/slash.go
@@ -86,6 +86,23 @@ func CommandFromValues(v url.Values) (Command, error) {
 	}, nil
 }
 
+// ValuesFromCommand returns a url.Values from the Command object. This is
+// mostly usefuly for testing.
+func ValuesFromCommand(cmd Command) url.Values {
+	v := make(url.Values)
+	v.Set("token", cmd.Token)
+	v.Set("team_id", cmd.TeamID)
+	v.Set("team_domain", cmd.TeamDomain)
+	v.Set("channel_id", cmd.ChannelID)
+	v.Set("channel_name", cmd.ChannelName)
+	v.Set("user_id", cmd.UserID)
+	v.Set("user_name", cmd.UserName)
+	v.Set("command", cmd.Command)
+	v.Set("text", cmd.Text)
+	v.Set("response_url", cmd.ResponseURL.String())
+	return v
+}
+
 // ParseRequest parses the form an then returns the extracted Command.
 func ParseRequest(r *http.Request) (Command, error) {
 	err := r.ParseForm()

--- a/slashtest/slashtest.go
+++ b/slashtest/slashtest.go
@@ -2,7 +2,10 @@
 package slashtest
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/ejholmes/slash"
 )
@@ -28,9 +31,34 @@ func NewRecorder() *ResponseRecorder {
 	}
 }
 
+// NewServer returns an httptest.Server that uses a ResponseRecorder as the
+// http.Handler
+func NewServer() (*ResponseRecorder, *httptest.Server) {
+	r := NewRecorder()
+	return r, httptest.NewServer(r)
+}
+
 // Respond sends the response on the Responses channel. If the channel is
 // blocked, it returns an error.
 func (r *ResponseRecorder) Respond(resp slash.Response) error {
+	return r.add(resp)
+}
+
+// ServeHTTP makes the ResponseRecorder implement the http.Handler method so it
+// can be used in combination with httptest.Server to record responses posted to
+// Slack.
+func (r *ResponseRecorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var resp slash.Response
+	if err := json.NewDecoder(req.Body).Decode(&resp); err != nil {
+		panic(err)
+	}
+
+	if err := r.add(resp); err != nil {
+		panic(err)
+	}
+}
+
+func (r *ResponseRecorder) add(resp slash.Response) error {
 	select {
 	case r.ch <- resp:
 		return nil

--- a/slashtest/slashtest_test.go
+++ b/slashtest/slashtest_test.go
@@ -1,0 +1,39 @@
+package slashtest
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/ejholmes/slash"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseServer(t *testing.T) {
+	h := slash.NewServer(slash.HandlerFunc(func(ctx context.Context, r slash.Responder, c slash.Command) error {
+		return r.Respond(slash.Reply("Hey"))
+	}))
+
+	// Responses from the above handler will be posted here.
+	r, s := NewServer()
+	defer s.Close()
+
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(fmt.Sprintf("response_url=%s", s.URL)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp := httptest.NewRecorder()
+
+	h.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	select {
+	case resp := <-r.Responses:
+		assert.Equal(t, "Hey", resp.Text)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/slashtest/slashtest_test.go
+++ b/slashtest/slashtest_test.go
@@ -20,7 +20,7 @@ func TestResponseServer(t *testing.T) {
 	}))
 
 	// Responses from the above handler will be posted here.
-	r, s := NewServer()
+	s := NewServer()
 	defer s.Close()
 
 	req, _ := http.NewRequest("POST", "/", strings.NewReader(fmt.Sprintf("response_url=%s", s.URL)))
@@ -31,7 +31,7 @@ func TestResponseServer(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Code)
 
 	select {
-	case resp := <-r.Responses:
+	case resp := <-s.Responses():
 		assert.Equal(t, "Hey", resp.Text)
 	case <-time.After(time.Second):
 		t.Fatal("timeout")

--- a/slashtest/slashtest_test.go
+++ b/slashtest/slashtest_test.go
@@ -1,39 +1,36 @@
-package slashtest
+package slashtest_test
 
 import (
 	"fmt"
-	"net/http"
 	"net/http/httptest"
-	"strings"
-	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/ejholmes/slash"
-	"github.com/stretchr/testify/assert"
+	"github.com/ejholmes/slash/slashtest"
 )
 
-func TestResponseServer(t *testing.T) {
+func ExampleServer() {
+	// A slash.Handler that will handle our slash commands.
 	h := slash.NewServer(slash.HandlerFunc(func(ctx context.Context, r slash.Responder, c slash.Command) error {
 		return r.Respond(slash.Reply("Hey"))
 	}))
 
 	// Responses from the above handler will be posted here.
-	s := NewServer()
-	defer s.Close()
+	responses := slashtest.NewServer()
+	defer responses.Close()
 
-	req, _ := http.NewRequest("POST", "/", strings.NewReader(fmt.Sprintf("response_url=%s", s.URL)))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req, _ := slashtest.NewRequest("POST", "/", responses.NewCommand())
 	resp := httptest.NewRecorder()
 
 	h.ServeHTTP(resp, req)
-	assert.Equal(t, http.StatusOK, resp.Code)
 
 	select {
-	case resp := <-s.Responses():
-		assert.Equal(t, "Hey", resp.Text)
+	case resp := <-responses.Responses:
+		fmt.Println(resp.Text)
+		// Output: Hey
 	case <-time.After(time.Second):
-		t.Fatal("timeout")
+		panic("timeout")
 	}
 }


### PR DESCRIPTION
This implements the http.Handler interface on top of ResponseRecorder, so it can be used in combination with httptest.Server to test responses posted to `response_url`.
